### PR TITLE
Create Manager Perfomance Improvements

### DIFF
--- a/create/cluster.go
+++ b/create/cluster.go
@@ -11,7 +11,10 @@ import (
 	"github.com/spf13/viper"
 )
 
-const defaultSourceURL = "github.com/joyent/triton-kubernetes"
+const (
+	defaultSourceURL = "github.com/joyent/triton-kubernetes"
+	defaultSourceRef = "master"
+)
 
 type baseClusterTerraformConfig struct {
 	Source string `json:"source"`
@@ -149,8 +152,13 @@ func getBaseClusterTerraformConfig(terraformModulePath string) (baseClusterTerra
 		baseSource = viper.GetString("source_url")
 	}
 
-	// Module Source location e.g. github.com/joyent/triton-kubernetes//terraform/modules/azure-rancher-k8s
-	cfg.Source = fmt.Sprintf("%s//%s", baseSource, terraformModulePath)
+	baseSourceRef := defaultSourceRef
+	if viper.IsSet("source_ref") {
+		baseSourceRef = viper.GetString("source_ref")
+	}
+
+	// Module Source location e.g. github.com/joyent/triton-kubernetes//terraform/modules/azure-rancher-k8s?ref=master
+	cfg.Source = fmt.Sprintf("%s//%s?ref=%s", baseSource, terraformModulePath, baseSourceRef)
 
 	// Name
 	if viper.IsSet("name") {

--- a/create/manager_triton.go
+++ b/create/manager_triton.go
@@ -60,8 +60,13 @@ func NewTritonManager(remoteBackend backend.Backend) error {
 		baseSource = viper.GetString("source_url")
 	}
 
-	// Module Source location e.g. github.com/joyent/triton-kubernetes//terraform/modules/triton-rancher
-	cfg.Source = fmt.Sprintf("%s//%s", baseSource, tritonRancherTerraformModulePath)
+	baseSourceRef := defaultSourceRef
+	if viper.IsSet("source_ref") {
+		baseSourceRef = viper.GetString("source_ref")
+	}
+
+	// Module Source location e.g. github.com/joyent/triton-kubernetes//terraform/modules/triton-rancher?ref=master
+	cfg.Source = fmt.Sprintf("%s//%s?ref=%s", baseSource, tritonRancherTerraformModulePath, baseSourceRef)
 
 	// Name
 	if viper.IsSet("name") {

--- a/create/node.go
+++ b/create/node.go
@@ -165,7 +165,12 @@ func getBaseNodeTerraformConfig(terraformModulePath, selectedCluster string, sta
 		baseSource = viper.GetString("source_url")
 	}
 
-	cfg.Source = fmt.Sprintf("%s//%s", baseSource, terraformModulePath)
+	baseSourceRef := defaultSourceRef
+	if viper.IsSet("source_ref") {
+		baseSourceRef = viper.GetString("source_ref")
+	}
+
+	cfg.Source = fmt.Sprintf("%s//%s?ref=%s", baseSource, terraformModulePath, baseSourceRef)
 
 	// Rancher Host Label
 	selectedHostLabel := ""

--- a/terraform/modules/aws-rancher-k8s/files/install_rancher_agent.sh.tpl
+++ b/terraform/modules/aws-rancher-k8s/files/install_rancher_agent.sh.tpl
@@ -8,7 +8,10 @@ if [ -n "$(command -v firewalld)" ]; then
 fi
 
 sudo curl ${docker_engine_install_url} | sh
-
+sudo service docker stop
+sudo bash -c 'echo "{
+  \"storage-driver\": \"overlay2\"
+}" > /etc/docker/daemon.json'
 sudo service docker restart
 
 sudo hostnamectl set-hostname ${hostname}

--- a/terraform/modules/azure-rancher-k8s/files/install_rancher_agent.sh.tpl
+++ b/terraform/modules/azure-rancher-k8s/files/install_rancher_agent.sh.tpl
@@ -8,7 +8,10 @@ if [ -n "$(command -v firewalld)" ]; then
 fi
 
 sudo curl ${docker_engine_install_url} | sh
-
+sudo service docker stop
+sudo bash -c 'echo "{
+  \"storage-driver\": \"overlay2\"
+}" > /etc/docker/daemon.json'
 sudo service docker restart
 
 sudo hostnamectl set-hostname ${hostname}

--- a/terraform/modules/gcp-rancher-k8s/files/install_rancher_agent.sh.tpl
+++ b/terraform/modules/gcp-rancher-k8s/files/install_rancher_agent.sh.tpl
@@ -8,7 +8,10 @@ if [ -n "$(command -v firewalld)" ]; then
 fi
 
 sudo curl ${docker_engine_install_url} | sh
-
+sudo service docker stop
+sudo bash -c 'echo "{
+  \"storage-driver\": \"overlay2\"
+}" > /etc/docker/daemon.json'
 sudo service docker restart
 
 sudo hostnamectl set-hostname ${hostname}

--- a/terraform/modules/triton-rancher-k8s/files/install_rancher_agent.sh.tpl
+++ b/terraform/modules/triton-rancher-k8s/files/install_rancher_agent.sh.tpl
@@ -15,6 +15,9 @@ sed 's~ExecStart=/usr/bin/dockerd -H\(.*\)~ExecStart=/usr/bin/dockerd --graph="/
 sudo mkdir /mnt/docker
 sudo bash -c "mv /var/lib/docker/* /mnt/docker/"
 sudo rm -rf /var/lib/docker
+sudo bash -c 'echo "{
+  \"storage-driver\": \"overlay2\"
+}" > /etc/docker/daemon.json'
 sudo systemctl daemon-reload
 sudo systemctl restart docker
 

--- a/terraform/modules/triton-rancher/files/install_docker_rancher.sh.tpl
+++ b/terraform/modules/triton-rancher/files/install_docker_rancher.sh.tpl
@@ -12,6 +12,9 @@ sed 's~ExecStart=/usr/bin/dockerd -H\(.*\)~ExecStart=/usr/bin/dockerd --graph="/
 sudo mkdir /mnt/docker
 sudo bash -c "mv /var/lib/docker/* /mnt/docker/"
 sudo rm -rf /var/lib/docker
+sudo bash -c 'echo "{
+  \"storage-driver\": \"overlay2\"
+}" > /etc/docker/daemon.json'
 sudo systemctl daemon-reload
 sudo systemctl restart docker
 

--- a/terraform/modules/triton-rancher/files/install_docker_rancher.sh.tpl
+++ b/terraform/modules/triton-rancher/files/install_docker_rancher.sh.tpl
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Install Docker
+sudo curl "${docker_engine_install_url}" | sh
+
+# Needed on CentOS, TODO: Replace firewalld with iptables.
+sudo service firewalld stop
+
+sudo service docker stop
+DOCKER_SERVICE=$(systemctl status docker.service --no-pager | grep Loaded | sed 's~\(.*\)loaded (\(.*\)docker.service\(.*\)$~\2docker.service~g')
+sed 's~ExecStart=/usr/bin/dockerd -H\(.*\)~ExecStart=/usr/bin/dockerd --graph="/mnt/docker" -H\1~g' $DOCKER_SERVICE > /home/ubuntu/docker.conf && sudo mv /home/ubuntu/docker.conf $DOCKER_SERVICE
+sudo mkdir /mnt/docker
+sudo bash -c "mv /var/lib/docker/* /mnt/docker/"
+sudo rm -rf /var/lib/docker
+sudo systemctl daemon-reload
+sudo systemctl restart docker
+
+# Run docker login if requested
+if [ "${rancher_registry_username}" != "" ]; then
+	sudo docker login -u ${rancher_registry_username} -p ${rancher_registry_password} ${rancher_registry}
+fi
+
+# Pull the rancher_server_image in preparation of running it
+sudo docker pull ${rancher_server_image}

--- a/terraform/modules/triton-rancher/files/install_rancher_master.sh.tpl
+++ b/terraform/modules/triton-rancher/files/install_rancher_master.sh.tpl
@@ -17,6 +17,10 @@ done
 # Run Rancher docker container
 container_id=""
 if [ "${ha}" = 1 ]; then
+	# Wait for mysql
+	printf 'Waiting for mysql'
+	nc -z ${mysqldb_host} ${mysqldb_port}
+
 	container_id=$(sudo docker run -d --restart=unless-stopped -p 8080:8080 -p 9345:9345 -e CATTLE_BOOTSTRAP_REQUIRED_IMAGE=${rancher_agent_image} ${rancher_server_image} \
 		--db-host ${mysqldb_host} --db-port ${mysqldb_port} --db-user ${mysqldb_user} --db-pass ${mysqldb_password} --db-name ${mysqldb_database_name} \
 		--advertise-address $(ip route get 1 | awk '{print $NF;exit}'))

--- a/terraform/modules/triton-rancher/files/setup_rancher.sh.tpl
+++ b/terraform/modules/triton-rancher/files/setup_rancher.sh.tpl
@@ -1,13 +1,13 @@
 #!/bin/bash
 
+sudo apt-get install jq -y || sudo yum install jq -y
+
 # Wait for Rancher UI to boot
 printf 'Waiting for Rancher to start'
 until $(curl --output /dev/null --silent --head --fail ${rancher_host}); do
     printf '.'
     sleep 5
 done
-
-sudo apt-get install jq -y || sudo yum install jq -y
 
 # Install docker-machine-driver-triton
 driver_id=$(curl -X POST \


### PR DESCRIPTION
- Reordered rancher master init scripts to increase parallelism. Tested with 2 Global Cluster Managers and a Mysql Instance. Timing test results below

|         |   Before  |   After   |
|:-------:|:---------:|:---------:|
| 1       | 7m26.958s |  4m19.435s |
| 2       | 6m13.746s | 4m28.133s |
| 3       |  7m1.761s | 3m28.602s |
| 4       | 7m34.512s | 4m15.306s  |
| 5       | 7m44.722s | 3m47.744s  |
| Average |  **7m12.34s** |  **4m4.805s** |

- Added SOURCE_REF option to allow specifying the branch/tag/commit the Terraform Modules should be downloaded from. `SOURCE_REF=go-cli ./triton-kubernetes`

@fayazg 