### PR TITLE
UX cleanup

### DIFF
--- a/create/manager_triton.go
+++ b/create/manager_triton.go
@@ -339,7 +339,7 @@ func NewTritonManager(remoteBackend backend.Backend) error {
 		}
 
 		continuePrompt := promptui.Select{
-			Label: "Attach another?",
+			Label: "Attach another",
 			Items: continueOptions,
 			Templates: &promptui.SelectTemplates{
 				Label:    "{{ . }}?",

--- a/create/manager_triton.go
+++ b/create/manager_triton.go
@@ -296,16 +296,30 @@ func NewTritonManager(remoteBackend backend.Backend) error {
 		return err
 	}
 
+	networks, err := tritonNetworkClient.List(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+
 	// Triton Network Names
 	if viper.IsSet("triton_network_names") {
 		cfg.TritonNetworkNames = viper.GetStringSlice("triton_network_names")
-	} else {
-		networks, err := tritonNetworkClient.List(context.Background(), nil)
-		if err != nil {
-			return err
+
+		// Verify triton network names
+		validNetworksMap := map[string]struct{}{}
+		validNetworksSlice := []string{}
+		for _, validNetwork := range networks {
+			validNetworksMap[validNetwork.Name] = struct{}{}
+			validNetworksSlice = append(validNetworksSlice, validNetwork.Name)
 		}
 
-		prompt := promptui.Select{
+		for _, network := range cfg.TritonNetworkNames {
+			if _, ok := validNetworksMap[network]; !ok {
+				return fmt.Errorf("Invalid Triton Network '%s', must be one of the following: %s", network, strings.Join(validNetworksSlice, ", "))
+			}
+		}
+	} else {
+		networkPrompt := promptui.Select{
 			Label: "Triton Networks to attach",
 			Items: networks,
 			Templates: &promptui.SelectTemplates{
@@ -316,12 +330,49 @@ func NewTritonManager(remoteBackend backend.Backend) error {
 			},
 		}
 
-		i, _, err := prompt.Run()
-		if err != nil {
-			return err
+		continueOptions := []struct {
+			Name  string
+			Value bool
+		}{
+			{"Yes", true},
+			{"No", false},
 		}
 
-		cfg.TritonNetworkNames = []string{networks[i].Name}
+		continuePrompt := promptui.Select{
+			Label: "Attach another?",
+			Items: continueOptions,
+			Templates: &promptui.SelectTemplates{
+				Label:    "{{ . }}?",
+				Active:   fmt.Sprintf("%s {{ .Name | underline }}", promptui.IconSelect),
+				Inactive: "  {{.Name}}",
+				Selected: "  Attach another? {{.Name}}",
+			},
+		}
+
+		networksChosen := []string{}
+		shouldPrompt := true
+		for shouldPrompt {
+			// Network Prompt
+			i, _, err := networkPrompt.Run()
+			if err != nil {
+				return err
+			}
+			networksChosen = append(networksChosen, networks[i].Name)
+
+			// Remove the chosen network from the list of choices
+			networkChoices := networkPrompt.Items.([]*network.Network)
+			remainingChoices := append(networkChoices[:i], networkChoices[i+1:]...)
+			networkPrompt.Items = remainingChoices
+
+			// Continue Prompt
+			i, _, err = continuePrompt.Run()
+			if err != nil {
+				return err
+			}
+			shouldPrompt = continueOptions[i].Value
+		}
+
+		cfg.TritonNetworkNames = networksChosen
 	}
 
 	if viper.IsSet("triton_image_name") && viper.IsSet("triton_image_version") {

--- a/create/manager_triton.go
+++ b/create/manager_triton.go
@@ -383,7 +383,9 @@ func NewTritonManager(remoteBackend backend.Backend) error {
 		cfg.TritonImageName = viper.GetString("triton_image_name")
 		cfg.TritonImageVersion = viper.GetString("triton_image_version")
 	} else {
-		listImageInput := compute.ListImagesInput{}
+		listImageInput := compute.ListImagesInput{
+			Name: "ubuntu-certified-16.04",
+		}
 		images, err := tritonComputeClient.Images().List(context.Background(), &listImageInput)
 		if err != nil {
 			return err

--- a/create/manager_triton.go
+++ b/create/manager_triton.go
@@ -362,14 +362,18 @@ func NewTritonManager(remoteBackend backend.Backend) error {
 			// Remove the chosen network from the list of choices
 			networkChoices := networkPrompt.Items.([]*network.Network)
 			remainingChoices := append(networkChoices[:i], networkChoices[i+1:]...)
-			networkPrompt.Items = remainingChoices
 
-			// Continue Prompt
-			i, _, err = continuePrompt.Run()
-			if err != nil {
-				return err
+			if len(remainingChoices) == 0 {
+				shouldPrompt = false
+			} else {
+				networkPrompt.Items = remainingChoices
+				// Continue Prompt
+				i, _, err = continuePrompt.Run()
+				if err != nil {
+					return err
+				}
+				shouldPrompt = continueOptions[i].Value
 			}
-			shouldPrompt = continueOptions[i].Value
 		}
 
 		cfg.TritonNetworkNames = networksChosen

--- a/create/node.go
+++ b/create/node.go
@@ -17,7 +17,7 @@ type baseNodeTerraformConfig struct {
 	Source string `json:"source"`
 
 	Hostname  string `json:"hostname"`
-	NodeCount int64
+	NodeCount int
 
 	RancherAPIURL        string                  `json:"rancher_api_url"`
 	RancherAccessKey     string                  `json:"rancher_access_key"`
@@ -239,7 +239,7 @@ func getBaseNodeTerraformConfig(terraformModulePath, selectedCluster string, sta
 	}
 
 	// Verifying node count
-	nodeCount, err := strconv.ParseInt(countInput, 10, 64)
+	nodeCount, err := strconv.Atoi(countInput)
 	if err != nil {
 		return baseNodeTerraformConfig{}, fmt.Errorf("node_count must be a valid number. Found '%s'.", countInput)
 	}

--- a/create/node.go
+++ b/create/node.go
@@ -266,3 +266,51 @@ func getBaseNodeTerraformConfig(terraformModulePath, selectedCluster string, sta
 
 	return cfg, nil
 }
+
+// Returns the hostnames that should be used when adding new nodes. Prevents naming collisions.
+func getNewHostnames(existingNames []string, nodeName string, nodesToAdd int) []string {
+	if nodesToAdd < 1 {
+		return []string{}
+	}
+
+	// If there's only one node to add, and the name doesn't exist
+	// just return the node name itself.
+	if nodesToAdd == 1 {
+		nodeNameUsed := false
+		for _, existingName := range existingNames {
+			if existingName == nodeName {
+				nodeNameUsed = true
+				break
+			}
+		}
+		if !nodeNameUsed {
+			return []string{nodeName}
+		}
+	}
+
+	// Find the number at which the series of hostnames should start.
+	startNum := 1
+	targetPrefix := nodeName + "-"
+	for _, existingName := range existingNames {
+		if !strings.HasPrefix(existingName, targetPrefix) {
+			continue
+		}
+
+		suffix := existingName[len(targetPrefix):]
+		numSuffix, err := strconv.Atoi(suffix)
+		if err != nil {
+			continue
+		}
+		if numSuffix >= startNum {
+			startNum = numSuffix + 1
+		}
+	}
+
+	// Build the list of hostnames
+	result := []string{}
+	for i := 0; i < nodesToAdd; i++ {
+		result = append(result, fmt.Sprintf("%s-%d", nodeName, startNum+i))
+	}
+
+	return result
+}

--- a/create/node.go
+++ b/create/node.go
@@ -280,21 +280,6 @@ func getNewHostnames(existingNames []string, nodeName string, nodesToAdd int) []
 		return []string{}
 	}
 
-	// If there's only one node to add, and the name doesn't exist
-	// just return the node name itself.
-	if nodesToAdd == 1 {
-		nodeNameUsed := false
-		for _, existingName := range existingNames {
-			if existingName == nodeName {
-				nodeNameUsed = true
-				break
-			}
-		}
-		if !nodeNameUsed {
-			return []string{nodeName}
-		}
-	}
-
 	// Find the number at which the series of hostnames should start.
 	startNum := 1
 	targetPrefix := nodeName + "-"

--- a/create/node.go
+++ b/create/node.go
@@ -17,7 +17,7 @@ type baseNodeTerraformConfig struct {
 	Source string `json:"source"`
 
 	Hostname  string `json:"hostname"`
-	NodeCount int
+	NodeCount int    `json:"-"`
 
 	RancherAPIURL        string                  `json:"rancher_api_url"`
 	RancherAccessKey     string                  `json:"rancher_access_key"`

--- a/create/node.go
+++ b/create/node.go
@@ -222,9 +222,12 @@ func getBaseNodeTerraformConfig(terraformModulePath, selectedCluster string, sta
 		prompt := promptui.Prompt{
 			Label: "Number of nodes to create",
 			Validate: func(input string) error {
-				_, err := strconv.ParseInt(input, 10, 64)
+				num, err := strconv.ParseInt(input, 10, 64)
 				if err != nil {
 					return errors.New("Invalid number")
+				}
+				if num <= 0 {
+					return errors.New("Number must be greater than 0")
 				}
 				return nil
 			},
@@ -243,6 +246,10 @@ func getBaseNodeTerraformConfig(terraformModulePath, selectedCluster string, sta
 	if err != nil {
 		return baseNodeTerraformConfig{}, fmt.Errorf("node_count must be a valid number. Found '%s'.", countInput)
 	}
+	if nodeCount <= 0 {
+		return baseNodeTerraformConfig{}, fmt.Errorf("node_count must be greater than 0. Found '%d'.", nodeCount)
+	}
+
 	cfg.NodeCount = nodeCount
 
 	// hostname

--- a/create/node_aws.go
+++ b/create/node_aws.go
@@ -167,7 +167,7 @@ func newAWSNode(selectedClusterManager, selectedCluster string, remoteBackend ba
 
 	// Add new node to terraform config with the new hostnames
 	for _, newHostname := range newHostnames {
-		cfgCopy := *(&cfg)
+		cfgCopy := cfg
 		cfgCopy.Hostname = newHostname
 		err = state.Add(fmt.Sprintf(awsNodeKeyFormat, newHostname), cfgCopy)
 		if err != nil {

--- a/create/node_azure.go
+++ b/create/node_azure.go
@@ -233,7 +233,7 @@ func newAzureNode(selectedClusterManager, selectedCluster string, remoteBackend 
 
 	// Add new node to terraform config with the new hostnames
 	for _, newHostname := range newHostnames {
-		cfgCopy := *(&cfg)
+		cfgCopy := cfg
 		cfgCopy.Hostname = newHostname
 		err = state.Add(fmt.Sprintf(azureNodeKeyFormat, newHostname), cfgCopy)
 		if err != nil {

--- a/create/node_azure.go
+++ b/create/node_azure.go
@@ -218,10 +218,27 @@ func newAzureNode(selectedClusterManager, selectedCluster string, remoteBackend 
 		cfg.AzurePublicKeyPath = expandedPublicKeyPath
 	}
 
-	// Add new node to terraform config
-	err = state.Add(fmt.Sprintf(azureNodeKeyFormat, cfg.Hostname), &cfg)
+	// Get existing node names
+	nodes, err := state.Nodes(selectedCluster)
 	if err != nil {
 		return err
+	}
+	existingNames := []string{}
+	for nodeName := range nodes {
+		existingNames = append(existingNames, nodeName)
+	}
+
+	// Determine what the hostnames should be for the new node(s)
+	newHostnames := getNewHostnames(existingNames, cfg.Hostname, cfg.NodeCount)
+
+	// Add new node to terraform config with the new hostnames
+	for _, newHostname := range newHostnames {
+		cfgCopy := *(&cfg)
+		cfgCopy.Hostname = newHostname
+		err = state.Add(fmt.Sprintf(azureNodeKeyFormat, newHostname), cfgCopy)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Create a temporary directory

--- a/create/node_gcp.go
+++ b/create/node_gcp.go
@@ -231,7 +231,7 @@ func newGCPNode(selectedClusterManager, selectedCluster string, remoteBackend ba
 
 	// Add new node to terraform config with the new hostnames
 	for _, newHostname := range newHostnames {
-		cfgCopy := *(&cfg)
+		cfgCopy := cfg
 		cfgCopy.Hostname = newHostname
 		err = state.Add(fmt.Sprintf(gcpNodeKeyFormat, newHostname), cfgCopy)
 		if err != nil {

--- a/create/node_test.go
+++ b/create/node_test.go
@@ -1,0 +1,48 @@
+package create
+
+import (
+	"fmt"
+	"testing"
+)
+
+var getNewHostnamesTestCases = []struct {
+	ExistingNames []string
+	NodeName      string
+	NodesToAdd    int
+	Expected      []string
+}{
+	// node count <= 0
+	{[]string{"test-1", "test-2"}, "test", 0, []string{}},
+	{[]string{"test-1", "test-2"}, "test", -10, []string{}},
+	// node count == 1
+	{[]string{"test-1", "test-2"}, "bar", 1, []string{"bar"}},
+	{[]string{"test"}, "test", 1, []string{"test-1"}},
+	// node count > 1
+	{[]string{"foo", "bar"}, "test", 3, []string{"test-1", "test-2", "test-3"}},
+	{[]string{"test"}, "test", 3, []string{"test-1", "test-2", "test-3"}},
+	{[]string{"test-1", "test-2", "bar-3", "bar-4"}, "test", 3, []string{"test-3", "test-4", "test-5"}},
+}
+
+func TestGetNewHostnames(t *testing.T) {
+	for _, tc := range getNewHostnamesTestCases {
+		output := getNewHostnames(tc.ExistingNames, tc.NodeName, tc.NodesToAdd)
+		if !isEqual(tc.Expected, output) {
+			msg := fmt.Sprintf("\nInput:    (%q, %q, %d)\n", tc.ExistingNames, tc.NodeName, tc.NodesToAdd)
+			msg += fmt.Sprintf("Output:   %q\n", output)
+			msg += fmt.Sprintf("Expected: %q\n", tc.Expected)
+			t.Error(msg)
+		}
+	}
+}
+
+func isEqual(expected, actual []string) bool {
+	if len(expected) != len(actual) {
+		return false
+	}
+	for index, expectedItem := range expected {
+		if actual[index] != expectedItem {
+			return false
+		}
+	}
+	return true
+}

--- a/create/node_test.go
+++ b/create/node_test.go
@@ -15,7 +15,7 @@ var getNewHostnamesTestCases = []struct {
 	{[]string{"test-1", "test-2"}, "test", 0, []string{}},
 	{[]string{"test-1", "test-2"}, "test", -10, []string{}},
 	// node count == 1
-	{[]string{"test-1", "test-2"}, "bar", 1, []string{"bar"}},
+	{[]string{"test-1", "test-2"}, "bar", 1, []string{"bar-1"}},
 	{[]string{"test"}, "test", 1, []string{"test-1"}},
 	// node count > 1
 	{[]string{"foo", "bar"}, "test", 3, []string{"test-1", "test-2", "test-3"}},

--- a/create/node_triton.go
+++ b/create/node_triton.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/joyent/triton-kubernetes/backend"
@@ -296,52 +295,4 @@ func newTritonNode(selectedClusterManager, selectedCluster string, remoteBackend
 	}
 
 	return nil
-}
-
-// Returns the hostnames that should be used when adding new nodes. Prevents naming collisions.
-func getNewHostnames(existingNames []string, nodeName string, nodesToAdd int) []string {
-	if nodesToAdd < 1 {
-		return []string{}
-	}
-
-	// If there's only one node to add, and the name doesn't exist
-	// just return the node name itself.
-	if nodesToAdd == 1 {
-		nodeNameUsed := false
-		for _, existingName := range existingNames {
-			if existingName == nodeName {
-				nodeNameUsed = true
-				break
-			}
-		}
-		if !nodeNameUsed {
-			return []string{nodeName}
-		}
-	}
-
-	// Find the number at which the series of hostnames should start.
-	startNum := 1
-	targetPrefix := nodeName + "-"
-	for _, existingName := range existingNames {
-		if !strings.HasPrefix(existingName, targetPrefix) {
-			continue
-		}
-
-		suffix := existingName[len(targetPrefix):]
-		numSuffix, err := strconv.Atoi(suffix)
-		if err != nil {
-			continue
-		}
-		if numSuffix >= startNum {
-			startNum = numSuffix + 1
-		}
-	}
-
-	// Build the list of hostnames
-	result := []string{}
-	for i := 0; i < nodesToAdd; i++ {
-		result = append(result, fmt.Sprintf("%s-%d", nodeName, startNum+i))
-	}
-
-	return result
 }

--- a/create/node_triton.go
+++ b/create/node_triton.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/joyent/triton-kubernetes/backend"
@@ -234,10 +235,25 @@ func newTritonNode(selectedClusterManager, selectedCluster string, remoteBackend
 		cfg.TritonMachinePackage = kvmPackages[i].Name
 	}
 
-	// Add new node to terraform config
-	err = state.Add(fmt.Sprintf(tritonNodeKeyFormat, cfg.Hostname), &cfg)
+	// Get existing node names
+	nodes, err := state.Nodes(selectedCluster)
 	if err != nil {
 		return err
+	}
+	existingNames := []string{}
+	for nodeName := range nodes {
+		existingNames = append(existingNames, nodeName)
+	}
+
+	// Determine what the hostnames should be for the new node(s)
+	newHostnames := getNewHostnames(existingNames, cfg.Hostname, cfg.NodeCount)
+
+	// Add new node to terraform config with the new hostnames
+	for _, newHostname := range newHostnames {
+		err = state.Add(fmt.Sprintf(tritonNodeKeyFormat, newHostname), &cfg)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Create a temporary directory
@@ -278,4 +294,52 @@ func newTritonNode(selectedClusterManager, selectedCluster string, remoteBackend
 	}
 
 	return nil
+}
+
+// Returns the hostnames that should be used when adding new nodes. Prevents naming collisions.
+func getNewHostnames(existingNames []string, nodeName string, nodesToAdd int) []string {
+	if nodesToAdd < 1 {
+		return []string{}
+	}
+
+	// If there's only one node to add, and the name doesn't exist
+	// just return the node name itself.
+	if nodesToAdd == 1 {
+		nodeNameUsed := false
+		for _, existingName := range existingNames {
+			if existingName == nodeName {
+				nodeNameUsed = true
+				break
+			}
+		}
+		if !nodeNameUsed {
+			return []string{nodeName}
+		}
+	}
+
+	// Find the number at which the series of hostnames should start.
+	startNum := 1
+	targetPrefix := nodeName + "-"
+	for _, existingName := range existingNames {
+		if !strings.HasPrefix(existingName, targetPrefix) {
+			continue
+		}
+
+		suffix := existingName[len(targetPrefix):]
+		numSuffix, err := strconv.Atoi(suffix)
+		if err != nil {
+			continue
+		}
+		if numSuffix >= startNum {
+			startNum = numSuffix + 1
+		}
+	}
+
+	// Build the list of hostnames
+	result := []string{}
+	for i := 0; i < nodesToAdd; i++ {
+		result = append(result, fmt.Sprintf("%s-%d", nodeName, startNum+i))
+	}
+
+	return result
 }

--- a/create/node_triton.go
+++ b/create/node_triton.go
@@ -249,7 +249,7 @@ func newTritonNode(selectedClusterManager, selectedCluster string, remoteBackend
 
 	// Add new node to terraform config with the new hostnames
 	for _, newHostname := range newHostnames {
-		cfgCopy := *(&cfg)
+		cfgCopy := cfg
 		cfgCopy.Hostname = newHostname
 		err = state.Add(fmt.Sprintf(tritonNodeKeyFormat, newHostname), cfgCopy)
 		if err != nil {

--- a/create/node_triton.go
+++ b/create/node_triton.go
@@ -250,7 +250,9 @@ func newTritonNode(selectedClusterManager, selectedCluster string, remoteBackend
 
 	// Add new node to terraform config with the new hostnames
 	for _, newHostname := range newHostnames {
-		err = state.Add(fmt.Sprintf(tritonNodeKeyFormat, newHostname), &cfg)
+		cfgCopy := *(&cfg)
+		cfgCopy.Hostname = newHostname
+		err = state.Add(fmt.Sprintf(tritonNodeKeyFormat, newHostname), cfgCopy)
 		if err != nil {
 			return err
 		}

--- a/create/node_triton.go
+++ b/create/node_triton.go
@@ -124,7 +124,7 @@ func newTritonNode(selectedClusterManager, selectedCluster string, remoteBackend
 		}
 
 		continuePrompt := promptui.Select{
-			Label: "Attach another?",
+			Label: "Attach another",
 			Items: continueOptions,
 			Templates: &promptui.SelectTemplates{
 				Label:    "{{ . }}?",

--- a/create/node_triton.go
+++ b/create/node_triton.go
@@ -147,14 +147,19 @@ func newTritonNode(selectedClusterManager, selectedCluster string, remoteBackend
 			// Remove the chosen network from the list of choices
 			networkChoices := networkPrompt.Items.([]*network.Network)
 			remainingChoices := append(networkChoices[:i], networkChoices[i+1:]...)
-			networkPrompt.Items = remainingChoices
 
-			// Continue Prompt
-			i, _, err = continuePrompt.Run()
-			if err != nil {
-				return err
+			if len(remainingChoices) == 0 {
+				shouldPrompt = false
+			} else {
+				networkPrompt.Items = remainingChoices
+
+				// Continue Prompt
+				i, _, err = continuePrompt.Run()
+				if err != nil {
+					return err
+				}
+				shouldPrompt = continueOptions[i].Value
 			}
-			shouldPrompt = continueOptions[i].Value
 		}
 
 		cfg.TritonNetworkNames = networksChosen

--- a/create/node_triton.go
+++ b/create/node_triton.go
@@ -177,7 +177,9 @@ func newTritonNode(selectedClusterManager, selectedCluster string, remoteBackend
 
 		// TODO: Verify Triton Image Name/Version
 	} else {
-		listImageInput := compute.ListImagesInput{}
+		listImageInput := compute.ListImagesInput{
+			Name: "ubuntu-certified-16.04",
+		}
 		images, err := tritonComputeClient.Images().List(context.Background(), &listImageInput)
 		if err != nil {
 			return err


### PR DESCRIPTION
- create node will now ask if you'd like to create multiple nodes with the same configuration
- Adding nodes to an existing cluster will no longer rely on the end user using a non conflicting node name. triton-kubernetes now manages the node name by appending a `-NUMBER` to it.
- All cloud provider images have been filtered to ubuntu
- Prompt for multiple triton networks

@fayazg 