### PR TITLE
update silent-install samples

### DIFF
--- a/examples/silent-install/sample-create-ha-cluster.yaml
+++ b/examples/silent-install/sample-create-ha-cluster.yaml
@@ -3,13 +3,41 @@ cluster_manager: ha-manager
 name: ha-cluster
 cluster_cloud_provider: triton
 k8s_plane_isolation: required
-private_registry: "docker-registry.joyent.com:5000"
+private_registry: ""
 private_registry_username: ""
 private_registry_password: ""
-k8s_registry: "docker-registry.joyent.com:5000"
+k8s_registry: ""
 k8s_registry_username: ""
 k8s_registry_password: ""
 triton_account: fayazg
 triton_key_path: ~/.ssh/id_rsa
 triton_key_id: 2c:53:bc:63:97:9e:79:3f:91:35:5e:f4:c8:23:88:37
 triton_url: https://us-east-1.api.joyent.com
+nodes:
+  - node_count: 3
+    rancher_host_label: etcd
+    hostname: test-etcd
+    triton_network_names:
+      - Joyent-SDC-Public
+    triton_image_name: ubuntu-certified-16.04
+    triton_image_version: 20180109
+    triton_ssh_user: ubuntu
+    triton_machine_package: k4-highcpu-kvm-1.75G
+  - node_count: 3
+    rancher_host_label: orchestration
+    hostname: test-orch
+    triton_network_names:
+      - Joyent-SDC-Public
+    triton_image_name: ubuntu-certified-16.04
+    triton_image_version: 20180109
+    triton_ssh_user: ubuntu
+    triton_machine_package: k4-highcpu-kvm-1.75G
+  - node_count: 1
+    rancher_host_label: compute
+    hostname: test-compute
+    triton_network_names:
+      - Joyent-SDC-Public
+    triton_image_name: ubuntu-certified-16.04
+    triton_image_version: 20180109
+    triton_ssh_user: ubuntu
+    triton_machine_package: k4-highcpu-kvm-1.75G

--- a/examples/silent-install/sample-create-ha-manager.yaml
+++ b/examples/silent-install/sample-create-ha-manager.yaml
@@ -1,12 +1,12 @@
 backend_provider: local
 name: ha-manager
 ha: true
-gcm_node_count: 2
-private_registry: "docker-registry.joyent.com:5000"
+gcm_node_count: 3
+private_registry: ""
 private_registry_username: ""
 private_registry_password: ""
-rancher_server_image: "docker-registry.joyent.com:5000/rancher/server:v1.6.14"
-rancher_agent_image: "docker-registry.joyent.com:5000/rancher/agent:v1.2.9"
+rancher_server_image: ""
+rancher_agent_image: ""
 triton_account: fayazg
 triton_key_path: ~/.ssh/id_rsa
 triton_key_id: 2c:53:bc:63:97:9e:79:3f:91:35:5e:f4:c8:23:88:37

--- a/examples/silent-install/sample-create-non-ha-cluster.yaml
+++ b/examples/silent-install/sample-create-non-ha-cluster.yaml
@@ -3,13 +3,23 @@ cluster_manager: non-ha-manager
 name: non-ha-cluster
 cluster_cloud_provider: triton
 k8s_plane_isolation: none
-private_registry: "docker-registry.joyent.com:5000"
+private_registry: ""
 private_registry_username: ""
 private_registry_password: ""
-k8s_registry: "docker-registry.joyent.com:5000"
+k8s_registry: ""
 k8s_registry_username: ""
 k8s_registry_password: ""
 triton_account: fayazg
 triton_key_path: ~/.ssh/id_rsa
 triton_key_id: 2c:53:bc:63:97:9e:79:3f:91:35:5e:f4:c8:23:88:37
 triton_url: https://us-east-1.api.joyent.com
+nodes:
+  - node_count: 3
+    rancher_host_label: compute
+    hostname: test-compute
+    triton_network_names:
+      - Joyent-SDC-Public
+    triton_image_name: ubuntu-certified-16.04
+    triton_image_version: 20180109
+    triton_ssh_user: ubuntu
+    triton_machine_package: k4-highcpu-kvm-1.75G

--- a/examples/silent-install/sample-create-non-ha-manager.yaml
+++ b/examples/silent-install/sample-create-non-ha-manager.yaml
@@ -2,11 +2,11 @@ backend_provider: local
 name: non-ha-manager
 ha: false
 gcm_node_count: 1
-private_registry: "docker-registry.joyent.com:5000"
+private_registry: ""
 private_registry_username: ""
 private_registry_password: ""
-rancher_server_image: "docker-registry.joyent.com:5000/rancher/server:v1.6.14"
-rancher_agent_image: "docker-registry.joyent.com:5000/rancher/agent:v1.2.9"
+rancher_server_image: ""
+rancher_agent_image: ""
 triton_account: fayazg
 triton_key_path: ~/.ssh/id_rsa
 triton_key_id: 2c:53:bc:63:97:9e:79:3f:91:35:5e:f4:c8:23:88:37


### PR DESCRIPTION
```bash
# create HA manager
triton-kubernetes create manager  --config examples/silent-install/sample-create-ha-manager.yaml --non-interactive
# create HA cluster
triton-kubernetes create cluster  --config examples/silent-install/sample-create-ha-cluster.yaml --non-interactive
```
- updated silent-install samples to include node details
- closes #65