### PR TITLE
Fixes #85 - Added embedded git hash

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,8 @@ cluster manager will manage environments running on any region of any supported 
 For an example set up, look at the How-To section.`,
 }
 
+var GitHash string
+
 // Execute adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -15,6 +14,6 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version number of triton-kubernetes",
 	Long:  `All software has versions. This is triton-kubernetes's version.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("triton-kubernetes v0.8.2")
+		fmt.Printf("triton-kubernetes v0.8.2 (%s)\n", GitHash)
 	},
 }

--- a/main.go
+++ b/main.go
@@ -2,6 +2,9 @@ package main
 
 import "github.com/joyent/triton-kubernetes/cmd"
 
+var GitHash string = "unknown commit"
+
 func main() {
+        cmd.GitHash = GitHash
 	cmd.Execute()
 }


### PR DESCRIPTION
With this change, you can now build the project with an embedded git hash by doing:
```
go build -ldflags "-X main.GitHash=$(git rev-list -1 HEAD)"
```