### PR TITLE
Add random, unique node suffix

### DIFF
--- a/create/node.go
+++ b/create/node.go
@@ -340,28 +340,15 @@ func getNewHostnames(existingNames []string, nodeName string, nodesToAdd int) []
 		return []string{}
 	}
 
-	// Find the number at which the series of hostnames should start.
-	startNum := 1
-	targetPrefix := nodeName + "-"
-	for _, existingName := range existingNames {
-		if !strings.HasPrefix(existingName, targetPrefix) {
-			continue
-		}
-
-		suffix := existingName[len(targetPrefix):]
-		numSuffix, err := strconv.Atoi(suffix)
-		if err != nil {
-			continue
-		}
-		if numSuffix >= startNum {
-			startNum = numSuffix + 1
-		}
-	}
-
 	// Build the list of hostnames
 	result := []string{}
-	for i := 0; i < nodesToAdd; i++ {
-		result = append(result, fmt.Sprintf("%s-%d", nodeName, startNum+i))
+	allNodeNames := existingNames
+	for len(result) < nodesToAdd {
+		newNodeName := fmt.Sprintf("%s-%s", nodeName, util.GetAlphaNum(6))
+		if util.IsUnique(allNodeNames, newNodeName) {
+			allNodeNames = append(allNodeNames, newNodeName)
+			result = append(result, newNodeName)
+		}
 	}
 
 	return result

--- a/create/node_test.go
+++ b/create/node_test.go
@@ -2,6 +2,7 @@ package create
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
 )
 
@@ -15,15 +16,18 @@ var getNewHostnamesTestCases = []struct {
 	{[]string{"test-1", "test-2"}, "test", 0, []string{}},
 	{[]string{"test-1", "test-2"}, "test", -10, []string{}},
 	// node count == 1
-	{[]string{"test-1", "test-2"}, "bar", 1, []string{"bar-1"}},
-	{[]string{"test"}, "test", 1, []string{"test-1"}},
+	{[]string{"test-1", "test-2"}, "bar", 1, []string{"bar-0nxrps"}},
+	{[]string{"test"}, "test", 1, []string{"test-hu5g3z"}},
 	// node count > 1
-	{[]string{"foo", "bar"}, "test", 3, []string{"test-1", "test-2", "test-3"}},
-	{[]string{"test"}, "test", 3, []string{"test-1", "test-2", "test-3"}},
-	{[]string{"test-1", "test-2", "bar-3", "bar-4"}, "test", 3, []string{"test-3", "test-4", "test-5"}},
+	{[]string{"foo", "bar"}, "test", 3, []string{"test-ymbuvf", "test-jfja9l", "test-kzt51k"}},
+	{[]string{"test"}, "test", 3, []string{"test-zvf07m", "test-n5ns55", "test-tspstz"}},
+	{[]string{"test-1", "test-2", "bar-3", "bar-4"}, "test", 3, []string{"test-tssh74", "test-hhcyz0", "test-3s415m"}},
+	// existing name (test-0nxrps & test-hhcyz0 are next 2 iterations)
+	{[]string{"test-0xmrt1", "test-hhcyz0"}, "test", 1, []string{"test-f3nab8"}},
 }
 
 func TestGetNewHostnames(t *testing.T) {
+	rand.Seed(1) // Force seed for reproducible results
 	for _, tc := range getNewHostnamesTestCases {
 		output := getNewHostnames(tc.ExistingNames, tc.NodeName, tc.NodesToAdd)
 		if !isEqual(tc.Expected, output) {

--- a/util/helper_utils.go
+++ b/util/helper_utils.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"math/rand"
+	"strings"
+	"time"
+)
+
+// alpha-numeric potential runes w/ ambiguous characters removed (i,o,q)
+var alpha = []rune("abcdefghjklmnprstuvwxyz0123456789")
+
+func init() {
+	rand.Seed(time.Now().UTC().UnixNano())
+}
+
+// GetAlphaNum returns a random alpha-numeric string
+func GetAlphaNum(length int) string {
+	res := make([]rune, length)
+	for i := range res {
+		res[i] = alpha[rand.Intn(len(alpha))]
+	}
+	return string(res)
+}
+
+// IsUnique checks for a unique value within a string array
+func IsUnique(arr []string, find string) bool {
+	for i := range arr {
+		if strings.EqualFold(find, arr[i]) {
+			return false
+		}
+	}
+	return true
+}

--- a/util/helper_utils_test.go
+++ b/util/helper_utils_test.go
@@ -1,0 +1,50 @@
+package util
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+// GetAlphaNum tests
+//   Verify random seeding occurs naturally, resulting in unique strings
+func TestGetAlphaNum(t *testing.T) {
+	s1 := GetAlphaNum(6)
+	s2 := GetAlphaNum(6)
+	if s1 == s2 {
+		t.Errorf("Random alpha strings should NOT match: %s == %s", s1, s2)
+	}
+}
+
+//   TestGetAlphaNum_Fixed verifies a forced seed provides a repeatable string
+func TestGetAlphaNum_Fixed(t *testing.T) {
+	rand.Seed(1)
+	s1 := GetAlphaNum(6)
+	rand.Seed(1)
+	s2 := GetAlphaNum(6)
+	if s1 != s2 {
+		t.Errorf("Random alpha strings SHOULD match: %s != %s", s1, s2)
+	}
+}
+
+// IsUnique tests
+var uniqueTestCases = []struct {
+	Search []string
+	Find   string
+	Result bool
+}{
+	{[]string{"abcdef", "123456"}, "abcdef", false},
+	{[]string{"abcdef", "123456"}, "abc123", true},
+}
+
+//  Validate unique testing for test cases above
+func TestIsUnique(t *testing.T) {
+	for _, tc := range uniqueTestCases {
+		if IsUnique(tc.Search, tc.Find) != tc.Result {
+			msg := fmt.Sprintf("\nSearch: %q\n", tc.Search)
+			msg += fmt.Sprintf("Find:   %q\n", tc.Find)
+			msg += fmt.Sprintf("Expected: %v\n", tc.Result)
+			t.Error(msg)
+		}
+	}
+}


### PR DESCRIPTION
This replaces the node number suffix with a random 6-digit alpha-numeric to make these more unique across multiple clusters.  The user-provided cluster name is the prefix, which should allow for identifying which cluster a node belongs to.

Although my first thought was that the node identifier (-1, -2, etc.) was nice to have cosmetically, it ultimately becomes fairly meaningless once nodes begin to be cycled.

Fixes #60 

Signed-off-by: Bryan Stone <aegixx@gmail.com>