### PR TITLE
Add Triton Volumes support

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,7 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.triton-kubernetes.yaml)")
 	rootCmd.PersistentFlags().Bool("non-interactive", false, "Prevent interactive prompts")
+	rootCmd.PersistentFlags().String("terraform-binary", "terraform", "The command to use for running the terraform binary. Defaults to 'terraform'.")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
@@ -49,6 +50,12 @@ func initConfig() {
 	viper.BindPFlag("non-interactive", rootCmd.Flags().Lookup("non-interactive"))
 	if viper.GetBool("non-interactive") {
 		fmt.Println("Running in non interactive mode")
+	}
+
+	viper.BindPFlag("terraform-binary", rootCmd.Flags().Lookup("terraform-binary"))
+	terraformBinary := viper.GetString("terraform-binary")
+	if terraformBinary != "terraform" {
+		fmt.Printf("Running terraform binary: %s\n", terraformBinary)
 	}
 
 	if cfgFile != "" { // enable ability to specify config file via flag

--- a/create/node_triton.go
+++ b/create/node_triton.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/joyent/triton-kubernetes/backend"
 	"github.com/joyent/triton-kubernetes/state"
+	"github.com/joyent/triton-kubernetes/util"
 
 	triton "github.com/joyent/triton-go"
 	"github.com/joyent/triton-go/authentication"
@@ -18,6 +20,34 @@ import (
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/viper"
 )
+
+// TODO Get volume sizes from triton-go once triton-go supports the ListVolumeSizes call
+type VolumeSize struct {
+	Size int
+	Type string
+}
+
+var tritonVolumeSizes = []VolumeSize{
+	VolumeSize{10240, "tritonnfs"},
+	VolumeSize{20480, "tritonnfs"},
+	VolumeSize{30720, "tritonnfs"},
+	VolumeSize{40960, "tritonnfs"},
+	VolumeSize{51200, "tritonnfs"},
+	VolumeSize{61440, "tritonnfs"},
+	VolumeSize{71680, "tritonnfs"},
+	VolumeSize{81920, "tritonnfs"},
+	VolumeSize{92160, "tritonnfs"},
+	VolumeSize{102400, "tritonnfs"},
+	VolumeSize{204800, "tritonnfs"},
+	VolumeSize{307200, "tritonnfs"},
+	VolumeSize{409600, "tritonnfs"},
+	VolumeSize{512000, "tritonnfs"},
+	VolumeSize{614400, "tritonnfs"},
+	VolumeSize{716800, "tritonnfs"},
+	VolumeSize{819200, "tritonnfs"},
+	VolumeSize{921600, "tritonnfs"},
+	VolumeSize{1024000, "tritonnfs"},
+}
 
 const (
 	tritonNodeKeyFormat                            = "module.node_triton_%s"
@@ -38,6 +68,8 @@ type tritonNodeTerraformConfig struct {
 	TritonSSHUser         string   `json:"triton_ssh_user,omitempty"`
 	TritonMachinePackage  string   `json:"triton_machine_package,omitempty"`
 	TritonVolumeMountPath string   `json:"triton_volume_mount_path"`
+	TritonVolumeSize      string   `json:"triton_volume_size"`
+	TritonVolumeType      string   `json:"triton_volume_type"`
 }
 
 // Adds new Triton nodes to the given cluster and manager.
@@ -293,6 +325,74 @@ func newTritonNode(selectedClusterManager, selectedCluster string, remoteBackend
 		cfg.TritonMachinePackage = packages[i].Name
 	}
 
+	// Triton Volume
+	mountPathIsSet := viper.IsSet("triton_volume_mount_path")
+	volumeSizeIsSet := viper.IsSet("triton_volume_size")
+	volumeTypeIsSet := viper.IsSet("triton_volume_type")
+	if mountPathIsSet {
+		cfg.TritonVolumeMountPath = viper.GetString("triton_volume_mount_path")
+		if volumeSizeIsSet {
+			cfg.TritonVolumeSize = viper.GetString("triton_volume_size")
+		}
+		if volumeTypeIsSet {
+			cfg.TritonVolumeType = viper.GetString("triton_volume_type")
+		}
+	} else if nonInteractiveMode && (volumeSizeIsSet || volumeTypeIsSet) {
+		return []string{}, errors.New("triton_volume_mount_path must be specified if volume size or type are set")
+	} else if !nonInteractiveMode {
+		// Ask if user wants to add a volume
+		shouldCreateVolume, err := util.PromptForConfirmation("Create a volume for this node", "Volume Created")
+		if err != nil {
+			return nil, err
+		}
+
+		if shouldCreateVolume {
+			// Mount path
+			if mountPathIsSet {
+				cfg.TritonVolumeMountPath = viper.GetString("triton_volume_mount_path")
+			} else {
+				prompt := promptui.Prompt{
+					Label: "Volume Mount Path",
+				}
+
+				result, err := prompt.Run()
+				if err != nil {
+					return nil, err
+				}
+				cfg.TritonVolumeMountPath = result
+			}
+
+			// Triton Volume Size and Type
+			shouldPromptSizeAndType := true
+			if volumeSizeIsSet && volumeTypeIsSet {
+				cfg.TritonVolumeSize = viper.GetString("triton_volume_size")
+				cfg.TritonVolumeType = viper.GetString("triton_volume_type")
+				shouldPromptSizeAndType = !isValidTritonVolumeSizeAndType(cfg.TritonVolumeSize, cfg.TritonVolumeType)
+			}
+
+			if shouldPromptSizeAndType {
+				prompt := promptui.Select{
+					Label: "Triton Volume Type And Size",
+					Items: tritonVolumeSizes,
+					Templates: &promptui.SelectTemplates{
+						Label:    "{{ . }}?",
+						Active:   fmt.Sprintf(`%s {{ .Type | underline}}{{ " - " | underline }}{{ .Size | underline }}{{ "MB" | underline }}`, promptui.IconSelect),
+						Inactive: `  {{ .Type }} - {{ .Size }}MB`,
+						Selected: fmt.Sprintf(`{{ "%s" | green }} {{ "Volume Type And Size:" | bold}} {{ .Type }}{{ " - " }}{{ .Size }}MB`, promptui.IconGood),
+					},
+				}
+
+				i, _, err := prompt.Run()
+				if err != nil {
+					return nil, err
+				}
+
+				cfg.TritonVolumeSize = strconv.Itoa(tritonVolumeSizes[i].Size)
+				cfg.TritonVolumeType = tritonVolumeSizes[i].Type
+			}
+		}
+	}
+
 	// Get existing node names
 	nodes, err := currentState.Nodes(selectedCluster)
 	if err != nil {
@@ -317,4 +417,13 @@ func newTritonNode(selectedClusterManager, selectedCluster string, remoteBackend
 	}
 
 	return newHostnames, nil
+}
+
+func isValidTritonVolumeSizeAndType(volumeSize, volumeType string) bool {
+	for _, volume := range tritonVolumeSizes {
+		if strconv.Itoa(volume.Size) == volumeSize && volume.Type == volumeType {
+			return true
+		}
+	}
+	return false
 }

--- a/create/node_triton.go
+++ b/create/node_triton.go
@@ -32,11 +32,12 @@ type tritonNodeTerraformConfig struct {
 	TritonKeyID   string `json:"triton_key_id"`
 	TritonURL     string `json:"triton_url,omitempty"`
 
-	TritonNetworkNames   []string `json:"triton_network_names,omitempty"`
-	TritonImageName      string   `json:"triton_image_name,omitempty"`
-	TritonImageVersion   string   `json:"triton_image_version,omitempty"`
-	TritonSSHUser        string   `json:"triton_ssh_user,omitempty"`
-	TritonMachinePackage string   `json:"triton_machine_package,omitempty"`
+	TritonNetworkNames    []string `json:"triton_network_names,omitempty"`
+	TritonImageName       string   `json:"triton_image_name,omitempty"`
+	TritonImageVersion    string   `json:"triton_image_version,omitempty"`
+	TritonSSHUser         string   `json:"triton_ssh_user,omitempty"`
+	TritonMachinePackage  string   `json:"triton_machine_package,omitempty"`
+	TritonVolumeMountPath string   `json:"triton_volume_mount_path"`
 }
 
 // Adds new Triton nodes to the given cluster and manager.

--- a/get/cluster.go
+++ b/get/cluster.go
@@ -125,14 +125,16 @@ func GetCluster(remoteBackend backend.Backend) error {
 		WorkingDir: tempDir,
 	}
 
+	terraformCmd := "/Users/chrisguevara/homdna-service/bin/terraform"
+
 	// Run terraform init
-	err = shell.RunShellCommand(&shellOptions, "terraform", "init", "-force-copy")
+	err = shell.RunShellCommand(&shellOptions, terraformCmd, "init", "-force-copy")
 	if err != nil {
 		return err
 	}
 
 	// Run terraform output
-	err = shell.RunShellCommand(&shellOptions, "terraform", "output", "-module", selectedClusterKey)
+	err = shell.RunShellCommand(&shellOptions, terraformCmd, "output", "-module", selectedClusterKey)
 	if err != nil {
 		return err
 	}

--- a/get/manager.go
+++ b/get/manager.go
@@ -79,14 +79,16 @@ func GetManager(remoteBackend backend.Backend) error {
 		WorkingDir: tempDir,
 	}
 
+	terraformCmd := "/Users/chrisguevara/homdna-service/bin/terraform"
+
 	// Run terraform init
-	err = shell.RunShellCommand(&shellOptions, "terraform", "init", "-force-copy")
+	err = shell.RunShellCommand(&shellOptions, terraformCmd, "init", "-force-copy")
 	if err != nil {
 		return err
 	}
 
 	// Run terraform output
-	err = shell.RunShellCommand(&shellOptions, "terraform", "output", "-module", "cluster-manager")
+	err = shell.RunShellCommand(&shellOptions, terraformCmd, "output", "-module", "cluster-manager")
 	if err != nil {
 		return err
 	}

--- a/shell/run_terraform.go
+++ b/shell/run_terraform.go
@@ -8,6 +8,8 @@ import (
 	"github.com/joyent/triton-kubernetes/state"
 )
 
+const terraformCmd = "/Users/chrisguevara/homdna-service/bin/terraform"
+
 func RunTerraformApplyWithState(state state.State) error {
 	// Create a temporary directory
 	tempDir, err := ioutil.TempDir("", "triton-kubernetes-")
@@ -29,13 +31,13 @@ func RunTerraformApplyWithState(state state.State) error {
 	}
 
 	// Run terraform init
-	err = RunShellCommand(&shellOptions, "terraform", "init", "-force-copy")
+	err = RunShellCommand(&shellOptions, terraformCmd, "init", "-force-copy")
 	if err != nil {
 		return err
 	}
 
 	// Run terraform apply
-	err = RunShellCommand(&shellOptions, "terraform", "apply", "-auto-approve")
+	err = RunShellCommand(&shellOptions, terraformCmd, "apply", "-auto-approve")
 	if err != nil {
 		return err
 	}
@@ -64,14 +66,14 @@ func RunTerraformDestroyWithState(currentState state.State, args []string) error
 	}
 
 	// Run terraform init
-	err = RunShellCommand(&shellOptions, "terraform", "init", "-force-copy")
+	err = RunShellCommand(&shellOptions, terraformCmd, "init", "-force-copy")
 	if err != nil {
 		return err
 	}
 
 	// Run terraform destroy
 	allArgs := append([]string{"destroy", "-force"}, args...)
-	err = RunShellCommand(&shellOptions, "terraform", allArgs...)
+	err = RunShellCommand(&shellOptions, terraformCmd, allArgs...)
 	if err != nil {
 		return err
 	}

--- a/shell/run_terraform.go
+++ b/shell/run_terraform.go
@@ -6,9 +6,8 @@ import (
 	"os"
 
 	"github.com/joyent/triton-kubernetes/state"
+	"github.com/spf13/viper"
 )
-
-const terraformCmd = "/Users/chrisguevara/homdna-service/bin/terraform"
 
 func RunTerraformApplyWithState(state state.State) error {
 	// Create a temporary directory
@@ -29,6 +28,9 @@ func RunTerraformApplyWithState(state state.State) error {
 	shellOptions := ShellOptions{
 		WorkingDir: tempDir,
 	}
+
+	terraformCmd := getTerraformCmd()
+	fmt.Printf("Using terraform binary: %s\n", terraformCmd)
 
 	// Run terraform init
 	err = RunShellCommand(&shellOptions, terraformCmd, "init", "-force-copy")
@@ -65,6 +67,9 @@ func RunTerraformDestroyWithState(currentState state.State, args []string) error
 		WorkingDir: tempDir,
 	}
 
+	terraformCmd := getTerraformCmd()
+	fmt.Printf("Using terraform binary: %s\n", terraformCmd)
+
 	// Run terraform init
 	err = RunShellCommand(&shellOptions, terraformCmd, "init", "-force-copy")
 	if err != nil {
@@ -79,4 +84,14 @@ func RunTerraformDestroyWithState(currentState state.State, args []string) error
 	}
 
 	return nil
+}
+
+// Returns the command to use to run terraform.
+// Returns the value of the terraform_binary config variable.
+// If that's not set, returns "terraform".
+func getTerraformCmd() string {
+	if viper.IsSet("terraform-binary") {
+		return viper.GetString("terraform-binary")
+	}
+	return "terraform"
 }

--- a/terraform/modules/triton-rancher-k8s-host/files/install_rancher_agent.sh.tpl
+++ b/terraform/modules/triton-rancher-k8s-host/files/install_rancher_agent.sh.tpl
@@ -31,3 +31,12 @@ fi
 
 # Run Rancher agent container
 ${rancher_agent_command}
+
+# Mount Volume
+if [ "${mount_path}" != "" ]; then
+	sudo apt-get update
+	sudo apt-get install -y nfs-common
+	sudo mkdir -p ${mount_path}
+	sudo echo '${nfs_path}	${mount_path}	nfs	auto,nofail,noatime,nolock,intr,tcp,actimeo=1800	0	0' >> /etc/fstab
+	sudo mount -a
+fi

--- a/terraform/modules/triton-rancher-k8s-host/main.tf
+++ b/terraform/modules/triton-rancher-k8s-host/main.tf
@@ -42,7 +42,7 @@ data "template_file" "install_rancher_agent" {
     rancher_registry_password = "${var.rancher_registry_password}"
 
     mount_path = "${var.triton_volume_mount_path}"
-    nfs_path = "${element(coalescelist(triton_volume.host_volume.*.filesystem_path, list("")), 0)}"
+    nfs_path   = "${element(coalescelist(triton_volume.host_volume.*.filesystem_path, list("")), 0)}"
   }
 }
 
@@ -67,7 +67,9 @@ resource "triton_machine" "host" {
 }
 
 resource "triton_volume" "host_volume" {
-  count = "${var.triton_volume_mount_path != "" ? 1 : 0}"
-  name = "${var.hostname}-Volume"
+  count    = "${var.triton_volume_mount_path != "" ? 1 : 0}"
+  name     = "${var.hostname}-Volume"
+  size     = "${var.triton_volume_size}"
+  type     = "${var.triton_volume_type}"
   networks = ["${data.triton_network.networks.*.id}"]
 }

--- a/terraform/modules/triton-rancher-k8s-host/main.tf
+++ b/terraform/modules/triton-rancher-k8s-host/main.tf
@@ -62,3 +62,8 @@ resource "triton_machine" "host" {
     role = "${element(keys(var.rancher_host_labels), 0)}"
   }
 }
+
+resource "triton_volume" "host_volume" {
+  name = "${var.hostname}-Volume"
+  networks = ["${data.triton_network.networks.*.id}"]
+}

--- a/terraform/modules/triton-rancher-k8s-host/main.tf
+++ b/terraform/modules/triton-rancher-k8s-host/main.tf
@@ -40,6 +40,9 @@ data "template_file" "install_rancher_agent" {
     rancher_registry          = "${var.rancher_registry}"
     rancher_registry_username = "${var.rancher_registry_username}"
     rancher_registry_password = "${var.rancher_registry_password}"
+
+    mount_path = "${var.triton_volume_mount_path}"
+    nfs_path = "${element(coalescelist(triton_volume.host_volume.*.filesystem_path, list("")), 0)}"
   }
 }
 
@@ -64,6 +67,7 @@ resource "triton_machine" "host" {
 }
 
 resource "triton_volume" "host_volume" {
+  count = "${var.triton_volume_mount_path != "" ? 1 : 0}"
   name = "${var.hostname}-Volume"
   networks = ["${data.triton_network.networks.*.id}"]
 }

--- a/terraform/modules/triton-rancher-k8s-host/variables.tf
+++ b/terraform/modules/triton-rancher-k8s-host/variables.tf
@@ -93,6 +93,16 @@ variable "rancher_registry_password" {
 }
 
 variable "triton_volume_mount_path" {
-  default = ""
+  default     = ""
   description = "The mount point on the node"
+}
+
+variable "triton_volume_size" {
+  default     = "10240"
+  description = "The desired minimum storage capacity for the triton volume in mebibytes."
+}
+
+variable "triton_volume_type" {
+  default     = "tritonnfs"
+  description = "The type of volume. Currently only tritonnfs is supported."
 }

--- a/terraform/modules/triton-rancher-k8s-host/variables.tf
+++ b/terraform/modules/triton-rancher-k8s-host/variables.tf
@@ -91,3 +91,8 @@ variable "rancher_registry_password" {
   default     = ""
   description = "The password to use."
 }
+
+variable "triton_volume_mount_path" {
+  default = ""
+  description = "The mount point on the node"
+}

--- a/terraform/modules/triton-rancher/main.tf
+++ b/terraform/modules/triton-rancher/main.tf
@@ -7,7 +7,7 @@ provider "triton" {
 
 locals {
   using_custom_tls_cert = "${var.rancher_tls_private_key_path != "" && var.rancher_tls_cert_path != ""}"
-  rancher_fqdn          = "${var.ha ? format("%s-proxy.svc.%s.us-east-1.triton.zone", lower(var.name), data.triton_account.main.id) : element(triton_machine.rancher_master.*.primaryip, 0)}"
+  rancher_fqdn          = "${var.ha ? format("%s-proxy.svc.%s.us-east-3b.triton.zone", lower(var.name), data.triton_account.main.id) : element(triton_machine.rancher_master.*.primaryip, 0)}"
   rancher_internal_url  = "${local.using_custom_tls_cert ? format("https://%s", local.rancher_fqdn) : format("http://%s", local.rancher_fqdn)}"
   rancher_url           = "${local.using_custom_tls_cert ? format("https://%s", var.rancher_domain_name) : format("http://%s", local.rancher_fqdn)}"
 }
@@ -21,10 +21,6 @@ data "triton_network" "networks" {
 
 data "triton_network" "public" {
   name = "Joyent-SDC-Public"
-}
-
-data "triton_network" "private" {
-  name = "Joyent-SDC-Private"
 }
 
 data "triton_image" "image" {

--- a/terraform/modules/triton-rancher/variables.tf
+++ b/terraform/modules/triton-rancher/variables.tf
@@ -74,7 +74,7 @@ variable "gcm_node_count" {
 }
 
 variable "gcm_private_network_name" {
-  default     = "Joyent-SDC-Private"
+  default     = "My-Fabric-Network"
   description = "Should Rancher be deployed in HA, this network will contain the mysqldb, Rancher master, nginx proxy, and bastion nodes. In non-HA mode, this will be ignored."
 }
 


### PR DESCRIPTION
This PR relies on `terraform-provider-triton` supporting Triton Volumes. Tracked [here](https://github.com/terraform-providers/terraform-provider-triton/pull/78).

While support for Triton Volumes is rolling out you can still run/test this branch by manually building/installing `terraform-provider-triton` locally. Then running terraform in the same path as the `terraform-provider-triton` binary.

Checkout and install `terraform-provider-triton`
```
go get github.com/terraform-providers/terraform-provider-triton
cd $GOPATH/src/github.com/terraform-providers/terraform-provider-triton
git remote add nimajalali https://github.com/nimajalali/terraform-provider-triton
git fetch nimajalali
git checkout nimajalali/add-support-for-volumes
go install
```

Download Terraform into $GOPATH/bin
```
cd $GOPATH/bin
wget "https://releases.hashicorp.com/terraform/0.11.5/terraform_0.11.5_darwin_amd64.zip"
unzip terraform_0.11.5_darwin_amd64.zip
```

Run triton-kubernetes with terraform-binary flag
```
cd $GOPATH/src/github.com/joyent/triton-kubernetes
git remote add nimajalali https://github.com/nimajalali/triton-kubernetes
git fetch nimajalali
git checkout nimajalali/triton-volumes
go build
SOURCE_URL=$GOPATH/src/github.com/joyent/triton-kubernetes ./triton-kubernetes create manager --terraform-binary $GOPATH/bin/terraform
```

@fayazg 