### PR TITLE
Add unit tests for get manager command

### DIFF
--- a/get/manager.go
+++ b/get/manager.go
@@ -28,7 +28,7 @@ func GetManager(remoteBackend backend.Backend) error {
 	if viper.IsSet("cluster_manager") {
 		selectedClusterManager = viper.GetString("cluster_manager")
 	} else if nonInteractiveMode {
-		return errors.New("cluster_manager must be specified")
+		return errors.New("Cluster manager must be specified")
 	} else {
 		prompt := promptui.Select{
 			Label: "Cluster Manager",

--- a/get/manager_test.go
+++ b/get/manager_test.go
@@ -1,0 +1,44 @@
+package get
+
+import (
+	"testing"
+
+	"github.com/joyent/triton-kubernetes/test_pkg"
+	"github.com/spf13/viper"
+)
+
+func TestNoClusterManager(t *testing.T) {
+
+	tCase := test_pkg.NewT(t)
+	localBackend := &test_pkg.MockEmptyBackend{}
+	err := GetManager(localBackend)
+
+	expected := "No cluster managers."
+	if expected != err.Error() {
+		tCase.Fatal("output", expected, err)
+	}
+}
+
+func TestMissingClusterManager(t *testing.T) {
+	viper.Set("non-interactive", true)
+	tCase := test_pkg.NewT(t)
+	localBackend := &test_pkg.MockBackend{}
+	err := GetManager(localBackend)
+
+	expected := "Cluster manager must be specified"
+	if expected != err.Error() {
+		tCase.Fatal("output", expected, err)
+	}
+}
+
+func TestClusterManagerNotExists(t *testing.T) {
+	viper.Set("cluster_manager", "prod-cluster")
+	tCase := test_pkg.NewT(t)
+	localBackend := &test_pkg.MockBackend{}
+	err := GetManager(localBackend)
+
+	expected := "Selected cluster manager 'prod-cluster' does not exist."
+	if expected != err.Error() {
+		tCase.Fatal("output", expected, err)
+	}
+}

--- a/test_pkg/backend_for_get.go
+++ b/test_pkg/backend_for_get.go
@@ -1,0 +1,49 @@
+package test_pkg
+
+import "github.com/joyent/triton-kubernetes/state"
+
+type MockEmptyBackend struct {
+}
+
+func (backend *MockEmptyBackend) State(name string) (state.State, error) {
+	return state.New(name, []byte("{}"))
+}
+
+func (backend *MockEmptyBackend) DeleteState(name string) error {
+	return nil
+}
+
+func (backend *MockEmptyBackend) PersistState(state state.State) error {
+	return nil
+}
+
+func (backend *MockEmptyBackend) States() ([]string, error) {
+	return []string{}, nil
+}
+
+func (backend *MockEmptyBackend) StateTerraformConfig(name string) (string, interface{}) {
+	return "", nil
+}
+
+type MockBackend struct {
+}
+
+func (backend *MockBackend) State(name string) (state.State, error) {
+	return state.New(name, []byte("{}"))
+}
+
+func (backend *MockBackend) DeleteState(name string) error {
+	return nil
+}
+
+func (backend *MockBackend) PersistState(state state.State) error {
+	return nil
+}
+
+func (backend *MockBackend) States() ([]string, error) {
+	return []string{"dev-manager", "beta-manager"}, nil
+}
+
+func (backend *MockBackend) StateTerraformConfig(name string) (string, interface{}) {
+	return "", nil
+}


### PR DESCRIPTION
- Add unit tests to valid user input against backend state for ` triton-kubernetes get manager` command