### PR TITLE
Problem: 'Working with CLI' link is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Triton Kubernetes is a multi-cloud Kubernetes solution. It has a global cluster manager (control plane) which can run on any cloud - Public, Private or Bare Metal and manages Kubernetes environments. The current release uses Triton (Joyent public cloud). With our forthcoming release, you will be able to run the global control plane on any cloud, bare metal or VMware.
 
-The cluster manager will manage environments running on any region of any supported cloud. Out of box, AWS, Azure, Google and Triton (public and private) are supported. If not using a cloud, environments on bare metal servers are also going to be supported in our forthcoming release. For an example set up, look at the [Working with the CLI](#Working-with-the-CLI) section.
+  The cluster manager will manage environments running on any region of any supported cloud. Out of box, AWS, Azure, Google and Triton (public and private) are supported. If not using a cloud, environments on bare metal servers are also going to be supported in our forthcoming release. For an example set up, look at the [Working with the CLI](#working-with-the-cli) section.
 
 ![Triton-Kubernetes](docs/imgs/Triton-Kubernetes.png)
 


### PR DESCRIPTION
Browser: Firefox Nightly, 62.0a1 (2018-06-04) (64-bit)
OS: Mac OS X, 10.11.6

Seems Firefox doesn't like the mixed-case version of the link.

Solution: Changed `#Working-with-the-CLI` to `#working-with-the-cli`