### PR TITLE
added new cli flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ Available Commands:
   version     Print the version number of triton-kubernetes
 
 Flags:
-      --config string     config file (default is $HOME/.triton-kubernetes.yaml)
-  -h, --help              help for triton-kubernetes
-      --non-interactive   Prevent interactive prompts
-  -t, --toggle            Help message for toggle
+      --config string             config file (default is $HOME/.triton-kubernetes.yaml)
+  -h, --help                      help for triton-kubernetes
+      --non-interactive           Prevent interactive prompts
+      --terraform-configuration   Create terraform configuration only
+  -t, --toggle                    Help message for toggle
 
 Use "triton-kubernetes [command] --help" for more information about a command.
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,7 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.triton-kubernetes.yaml)")
 	rootCmd.PersistentFlags().Bool("non-interactive", false, "Prevent interactive prompts")
+	rootCmd.PersistentFlags().Bool("terraform-configuration", false, "Create terraform configuration only")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
@@ -50,7 +51,10 @@ func initConfig() {
 	if viper.GetBool("non-interactive") {
 		fmt.Println("Running in non interactive mode")
 	}
-
+	viper.BindPFlag("terraform-configuration", rootCmd.Flags().Lookup("terraform-configuration"))
+	if viper.GetBool("terraform-configuration") {
+		fmt.Println("Will not create infrastructure, only terraform configuration")
+	}
 	if cfgFile != "" { // enable ability to specify config file via flag
 		viper.SetConfigFile(cfgFile)
 	} else {

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -51,6 +51,10 @@ triton-kubernetes --help
 
 `triton-kubernetes` can run as an interactive cli, or in [silent mode](silent-install-yaml.md) (`--non-interactive`) using yaml configuration files.
 
+When creating/modifying infrastructure, `--terraform-configuration` flag can be used to create/modify existing terraform configuration without changing the actual infrastructure. For where to find the state files, look at [Backend State](#backend-state) section.
+
+> <sub>WARN: `triton-kubernetes` can not handle manually modified configuration files.</sub>
+
 The `triton-kubernetes` cli can:
 
 - create a cluster manager

--- a/shell/run_terraform.go
+++ b/shell/run_terraform.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 
 	"github.com/joyent/triton-kubernetes/state"
+	"github.com/spf13/viper"
 
 	getter "github.com/hashicorp/go-getter"
 )
@@ -61,6 +62,11 @@ func installThirdPartyProviders(workingDirectory string) error {
 }
 
 func RunTerraformApplyWithState(state state.State) error {
+	if viper.GetBool("terraform-configuration") {
+		fmt.Println("Updating terraform configuration")
+		return nil
+	}
+
 	// Create a temporary directory
 	tempDir, err := ioutil.TempDir("", "triton-kubernetes-")
 	if err != nil {


### PR DESCRIPTION
`--terraform-configuration` flag will skip running terraform apply
- generates/updates terraform config without creating/modifying infrastructure
 configuration will be in json format and can be converted using a tool like [json2hcl](https://github.com/kvz/json2hcl) if needed
- resolves #145